### PR TITLE
Use python-serial 3.0 style properties to set serial and baudrate.

### DIFF
--- a/libezgripper/lib_robotis.py
+++ b/libezgripper/lib_robotis.py
@@ -147,8 +147,8 @@ class USB2Dynamixel_Device():
             # Closing the device first seems to prevent "Access Denied" errors on WinXP
             # (Conversations with Brian Wu @ MIT on 6/23/2010)
             self.servo_dev.close()  
-            self.servo_dev.setParity('N')
-            self.servo_dev.setStopbits(1)
+            self.servo_dev.parity = serial.PARITY_NONE
+            self.servo_dev.stopbits = serial.STOPBITS_ONE
             self.servo_dev.open()
 
             self.servo_dev.flushOutput()


### PR DESCRIPTION
Fixes an execption being thrown while running on Ubuntu 16.04.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sakerobotics/libezgripper/2)
<!-- Reviewable:end -->
